### PR TITLE
Add build-essential to pipx installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="kjake"
 
 RUN  apt-get -qq update && \
       apt-get install -y --no-install-recommends \
+         build-essential \
          python3 \
          python3-venv \
          pipx \


### PR DESCRIPTION
## Summary
- add build-essential to the base image dependencies so pipx can compile pycryptodome during streamlink install

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e2ace80ac8325b322e11438501d76)