### PR TITLE
Add libxml development packages for lxml build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ LABEL maintainer="kjake"
 
 RUN  apt-get -qq update && \
       apt-get install -y --no-install-recommends \
+         build-essential \
+         libxml2-dev \
+         libxslt-dev \
          python3 \
          python3-venv \
          pipx \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN  apt-get -qq update && \
       apt-get install -y --no-install-recommends \
          build-essential \
          libxml2-dev \
-         libxslt-dev \
+         libxslt1-dev \
          python3 \
          python3-venv \
          pipx \


### PR DESCRIPTION
## Summary
- add libxml2 and libxslt development packages to support lxml during pipx installation

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e2ace80ac8325b322e11438501d76)