### PR TITLE
Add build prerequisites for multi-architecture streamlink installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="kjake"
 RUN  apt-get -qq update && \
       apt-get install -y --no-install-recommends \
          build-essential \
+         python3-dev \
          libxml2-dev \
          libxslt1-dev \
          python3 \

--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ docker run -d \
 > [!NOTE]
 > The stream file will be named as `streamName - Year-Month-Day HourMinuteSecond - streamTitle.mkv`.
 
+## Building locally
+
+When building or running `pipx install streamlink` on architectures where a prebuilt `lxml` wheel is unavailable (for example, `s390x`), ensure the Python development headers and XML tooling are present so `lxml` can compile successfully:
+
+```shell
+apt-get update && \
+  apt-get install -y --no-install-recommends \
+    python3-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    build-essential
+```
+
+The Dockerfile already installs these dependencies to keep the image build working across multiple architectures.
+
 ## Acknowledgments
 - Thanks to [@lauwarm](https://github.com/lauwarm/docker-streamlink-recorder) for the original streamlink container.
 


### PR DESCRIPTION
## Summary
- install python3-dev alongside existing XML build dependencies so pipx can compile lxml on architectures without wheels
- document the required build packages for local or non-amd64 streamlink installations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e39e6d7d8832591c9ef3678650a6a)